### PR TITLE
fortmatting for TCP_connections section + small improvemetns to .css

### DIFF
--- a/rust.css
+++ b/rust.css
@@ -139,9 +139,9 @@ h6 {
 }
 
 nav {
-    /*column-count: 2;
-    -moz-column-count: 2;
-    -webkit-column-count: 2;*/
+    column-count: auto;
+    -moz-column-count: auto;
+    -webkit-column-count: auto;
     font-size: 15px;
     margin: 0 0 1em 0;
 }
@@ -291,19 +291,19 @@ dl {
 dd {
     margin-left: 0;
 }
-/*
+
 nav ul {
+    display: block;
     list-style-type: none;
     margin: 0;
-    padding-left: 0px;
+    padding-left: 2em;
 }
 
 /* Only display one level of hierarchy in the TOC */
-/*
+
 nav ul ul {
-    display: none;
+    display: block;
 }
-*/
 
 sub,
 sup {

--- a/rust.css
+++ b/rust.css
@@ -78,6 +78,7 @@ h1, h2, h3, h4, h5, h6, nav, #versioninfo {
     font-family: "Fira Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 h1, h2, h3, h4, h5, h6 {
+    counter-reset: paragraph; // to reset paragraph counter on every header
     color: black;
     font-weight: 400;
     line-height: 1.1;
@@ -136,6 +137,16 @@ h6 {
     h3 {
         font-size: 26px;
     }
+}
+
+/* Number paragraphs */
+p:before {
+    align: left;
+    position: absolute;
+    margin-left: -29px;
+    color: #CCC;
+    content: counter(paragraph);
+    counter-increment: paragraph;
 }
 
 nav {
@@ -322,6 +333,7 @@ hr {
 table {
     border-collapse: collapse;
     border-spacing: 0;
+    margin-bottom: 6px;
     overflow-x: auto;
     display: block;
 }

--- a/spec.md
+++ b/spec.md
@@ -968,28 +968,29 @@ packets must be sent as they are smaller than OOB packets.
 
 OOB recv and data packets must be handled and passed to the module using it.
 
-# TCP_connections.txt
+# TCP_connections
 
-TCP_connections takes care of handling multiple TCP client instances to
+`TCP_connections` takes care of handling multiple TCP client instances to
 establish a reliable connection via TCP relays to a friend. Connecting to a
-friend with only one relay would not be very reliable, so TCP_connections
+friend with only one relay would not be very reliable, so `TCP_connections`
 provides the level of abstraction needed to manage multiple relays. For
 example, it ensures that if a relay goes down, the connection to the peer will
 not be impacted. This is done by connecting to the other peer with more than
 one relay.
 
-TCP_connections is above TCP_client and below net_crypto. 
+`TCP_connections` is above [`TCP client`](#tcp-client) and below `net_crypto`.
 
-A TCP connection in TCP_connections is defined as a connection to a peer though
-one or more TCP relays. To connect to another peer with TCP_connections, a
-connection in TCP_connections to the peer with DHT public key X will be
-created. Some TCP relays which we know the peer is connected to will then be
-associated with that peer. If the peer isn't connected directly yet, these
-relays will be the ones that the peer has sent to us via the onion module. The
-peer will also send some relays it is directly connected to once a connection
-is established, however, this is done by another module.
+A TCP connection in `TCP_connections` is defined as a connection to a peer
+though one or more TCP relays. To connect to another peer with
+`TCP_connections`, a connection in `TCP_connections` to the peer with DHT
+public key X will be created. Some TCP relays which we know the peer is
+connected to will then be associated with that peer. If the peer isn't
+connected directly yet, these relays will be the ones that the peer has sent to
+us via the onion module. The peer will also send some relays it is directly
+connected to once a connection is established, however, this is done by another
+module.
 
-TCP_connections has a list of all relays it is connected to. It tries to keep
+`TCP_connections` has a list of all relays it is connected to. It tries to keep
 the number of relays it is connected to as small as possible in order to
 minimize load on relays and lower bandwidth usage for the client. The desired
 number of TCP relay connections per peer is set to 3 in toxcore with the
@@ -1002,7 +1003,7 @@ amount of relays because of other friends this is where this maximum comes into
 play. There is no reason why this number is 6 but in toxcore it has to be at
 least double than the desired number (3) because the code assumes this.
 
-If necessary, TCP_connections will connect to TCP relays to use them to send
+If necessary, `TCP_connections` will connect to TCP relays to use them to send
 onion packets. This is only done if there is no UDP connection to the network.
 When there is a UDP connection, packets are sent with UDP only because sending
 them with TCP relays can be less reliable. It is also important that we are
@@ -1019,9 +1020,9 @@ is sent to them, there should be no more peers connecting to us via TCP relays.
 This may be a way to further reduce load on TCP relays, however, more research
 is needed before it is implemented.
 
-TCP_connections picks one relay and uses only it for sending data to the other
-peer. The reason for not picking a random connected relay for each packet is
-that it severely deteriorates the quality of the link between two peers and
+`TCP_connections` picks one relay and uses only it for sending data to the
+other peer. The reason for not picking a random connected relay for each packet
+is that it severely deteriorates the quality of the link between two peers and
 makes performance of lossy video and audio transmissions really poor. For this
 reason, one relay is picked and used to send all data. If for any reason no
 more data can be sent through that relay, the next relay is used. This may
@@ -1030,19 +1031,19 @@ dropped if this occurs. Relays are only dropped if they time out or if they
 become useless (if the relay is one too many or is no longer being used to
 relay data to any peers).
 
-TCP_connections  in toxcore also contains a mechanism to make connections go to
-sleep. TCP connections to other peers may be put to sleep if the connection to
-the peer establishes itself with UDP after the connection is established with
-TCP. UDP is the method preferred by net_crypto to communicate with other peers.
-In order to keep track of the relays which were used to connect with the other
-peer in case the UDP connection fails, they are saved by TCP_connections when
-the connection is put to sleep. Any relays which were only used by this
-redundant connection are saved then disconnected from. If the connection is
-awakened, the relays are reconnected to and the connection is reestablished.
-Putting a connection to sleep is the same as saving all the relays used by the
-connection and removing the connection. Awakening the connection is the same as
-creating a new connection with the same parameters and restoring all the
-relays.
+`TCP_connections` in toxcore also contains a mechanism to make connections go
+to sleep. TCP connections to other peers may be put to sleep if the connection
+to the peer establishes itself with UDP after the connection is established
+with TCP. UDP is the method preferred by `net_crypto` to communicate with other
+peers. In order to keep track of the relays which were used to connect with
+the other peer in case the UDP connection fails, they are saved by
+`TCP_connections` when the connection is put to sleep. Any relays which were
+only used by this redundant connection are saved then disconnected from. If the
+connection is awakened, the relays are reconnected to and the connection is
+reestablished. Putting a connection to sleep is the same as saving all the
+relays used by the connection and removing the connection. Awakening the
+connection is the same as creating a new connection with the same parameters
+and restoring all the relays.
 
 A method to detect potentially dysfunctional relays that try to disrupt the
 network by lying that they are connecting to a peer when they are not or that
@@ -1050,22 +1051,22 @@ maliciously drop all packets should be considered. Toxcore doesn't currently
 implement such a system and adding one requires more research and likely also
 requires extending the protocol.
 
-When TCP connections connects to a relay it will create a new TCP_client
-instance for that relay. At any time if the TCP_client instance reports that it
-has disconnected, the TCP relay will be dropped. Once the TCP relay reports
-that it is connected, TCP_connections will find all the connections that are
-associated to the relay and announce to the relay that it wants to connect to
-each of them with routing requests. If the relay reports that the peer for a
-connection is online, the connection number and relay will be used to send data
-in that connection with data packets. If the peer isn't reported as online but
-the relay is associated to a connection, TCP OOB (out of band) packets will be
-used to send data instead of data packets. TCP OOB packets are used in this
-case since the relay most likely has the peer connected but it has not sent a
-routing request to connect to us.
+When TCP connections connects to a relay it will create a new
+[`TCP_client`](#tcp-client) instance for that relay. At any time if the
+`TCP_client` instance reports that it has disconnected, the TCP relay will be
+dropped. Once the TCP relay reports that it is connected, `TCP_connections`
+will find all the connections that are associated to the relay and announce to
+the relay that it wants to connect to each of them with routing requests. If
+the relay reports that the peer for a connection is online, the connection
+number and relay will be used to send data in that connection with data
+packets. If the peer isn't reported as online but the relay is associated to a
+connection, TCP OOB (out of band) packets will be used to send data instead of
+data packets. TCP OOB packets are used in this case since the relay most likely
+has the peer connected but it has not sent a routing request to connect to us.
 
-TCP_connections is used as the bridge between individual TCP_client instances
-and net_crypto, or the bridge between individual connections and something that
-requires an interface that looks like one connection.
+`TCP_connections` is used as the bridge between individual TCP_client instances
+and `net_crypto`, or the bridge between individual connections and something
+that requires an interface that looks like one connection.
 
 # TCP_server.txt
 


### PR DESCRIPTION
Now generated table of contents in HTML will not have bullet points.

Before:
![bullet points](https://cloud.githubusercontent.com/assets/3148759/13197958/1d21ebfe-d7f4-11e5-9c50-80ae6e2ca7ae.png)

Change:
![no bullet points](https://cloud.githubusercontent.com/assets/3148759/13197962/3003558c-d7f4-11e5-827b-3f35bb1670e8.png)
