### PR TITLE
TCP Nonce use is opposite to what's described in the spec

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1741,8 +1741,8 @@ the server and the nonce:
 | `32`   | Public key |
 | `24`   | Base nonce |
 
-The base nonce is the one TCP client wants the TCP server to use to encrypt the
-packets sent to the TCP client.
+The base nonce is the one TCP client wants the TCP server to use to decrypt the
+packets received from the TCP client.
 
 The first 32 bytes are the public key (DHT public key) that the TCP client is
 announcing itself to the server with. The next 24 bytes are a nonce which the
@@ -1750,8 +1750,8 @@ TCP client uses along with the secret key associated with the public key in the
 first 32 bytes of the packet to encrypt the rest of this 'packet'. The
 encrypted part of this packet contains a temporary public key that will be used
 for encryption during the connection and will be discarded after. It also
-contains a base nonce which will be used later for encrypting packets sent to
-the TCP client.
+contains a base nonce which will be used later for encrypting packets received
+from the TCP client.
 
 If the server decrypts successfully the encrypted data in the handshake packet
 and responds with the following handshake response of length 96 bytes:
@@ -1769,8 +1769,8 @@ of the client and the nonce:
 | `32`   | Public key |
 | `24`   | Base nonce |
 
-The base nonce is the one the TCP server wants the TCP client to use to encrypt
-the packets sent to the TCP server.
+The base nonce is the one the TCP server wants the TCP client to use to decrypt
+the packets received from the TCP server.
 
 The client already knows the long term public key of the server so it is
 omitted in the response, instead only a nonce is present in the unencrypted

--- a/spec.md
+++ b/spec.md
@@ -1750,7 +1750,7 @@ TCP client uses along with the secret key associated with the public key in the
 first 32 bytes of the packet to encrypt the rest of this 'packet'. The
 encrypted part of this packet contains a temporary public key that will be used
 for encryption during the connection and will be discarded after. It also
-contains a base nonce which will be used later for encrypting packets received
+contains a base nonce which will be used later for decrypting packets received
 from the TCP client.
 
 If the server decrypts successfully the encrypted data in the handshake packet


### PR DESCRIPTION
I'm implementing a toy tox tcp client in python and found a little mismatch between the spec and reality.

Nonce sent in initial by client is later used in encrypting
client->server messages. Similarly, nonce sent by the server
is later used in encrypting server->client messages.

Proof:
https://github.com/TokTok/c-toxcore/blob/bb5f8a17103537caa09bcf14130debe3210fb61f/toxcore/TCP_server.c#L545

    memcpy(con->recv_nonce, plain + CRYPTO_PUBLIC_KEY_SIZE, CRYPTO_NONCE_SIZE);

The nonce used by the TCP server for messages received from
client is copied from the initial packet received from the client.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/spec/63)
<!-- Reviewable:end -->
